### PR TITLE
feat: Use docker-socket-proxy for better security

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ services:
     image: ghcr.io/clemcer/loggifly:latest
     container_name: loggifly
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
 #      - ./config.yaml:/app/config.yaml  # Path to your config file (ignore if you are only using environment variables)
     environment:
+      DOCKER_HOST: tcp://socket-proxy:2375
       # Choose at least one notification service
       NTFY_URL: "https://ntfy.sh"       # or your self-hosted instance
       NTFY_TOPIC: "your_topic"          # e.g., "docker_alerts"
@@ -96,6 +96,17 @@ services:
       CONTAINERS: "vaultwarden,audiobookshelf"        # Comma-separated list
       GLOBAL_KEYWORDS: "error,failed login,password"  # Basic keyword monitoring
       GLOBAL_KEYWORDS_WITH_ATTACHMENT: "critical"     # Attaches a log file to the notification
+  socket-proxy:
+    image: lscr.io/linuxserver/socket-proxy
+    environment:
+      - CONTAINERS=1
+      - POST=0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /run
     restart: unless-stopped 
 ```
 </details>
@@ -290,6 +301,7 @@ Except for container specific settings and regex patterns you can configure most
 | `DISBLE_START_MESSAGE`          | Disable startup message.                                  | False     |
 | `DISBLE_SHUTDOWN_MESSAGE`       | Disable shutdown message.                                 | False     |
 | `DISABLE_RESTART_MESSAGE`       | Disable message on config change when program restarts.| False     |
+| `DOCKER_HOST`                   | Docker socket proxy URL                                    | _N/A_ |
 
 </details>
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,9 +4,19 @@ services:
     image: ghcr.io/clemcer/loggifly:latest
     container_name: loggifly
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
       - ./logsend/config.yaml:/app/config.yaml
     environment:
-      - TZ=Europe/Berlin
+      TZ: Europe/Berlin
+      DOCKER_HOST: tcp://socket-proxy:2375
     restart: unless-stopped
-
+  socket-proxy:
+    image: lscr.io/linuxserver/socket-proxy
+    environment:
+      - CONTAINERS=1
+      - POST=0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /run


### PR DESCRIPTION
Since this project requires a

*  limited set of docker socket capabilities (list containers, read logs) and
*  these are read-only in nature

it should use a [**docker socket proxy** to limit its access to docker](https://security.stackexchange.com/questions/270561/does-a-docker-socket-proxy-improve-security). Exposing the full socket, even in read-only mode, is basically like handing over `sudo` to the application when all it needs is to read one user file.

The python package/method already in use, [`docker.from_env()`](https://docker-py.readthedocs.io/en/stable/client.html#docker.client.from_env), supports reading docker over tcp with `DOCKER_HOST` env so the only change that is needed is modifying the recommended compose stack to use a proxy service instead of directly mounting `docker.sock`

This PR modifies docker-compose.yaml and the example in the README to use [lscr.io/linuxserver/socket-proxy](https://docs.linuxserver.io/images/docker-socket-proxy/) but there are other alternative implementations, if you would prefer

* https://github.com/Tecnativa/docker-socket-proxy
* https://github.com/11notes/docker-socket-proxy

I can modify the stack to use one of these if you want.