### PR TITLE
Add case sensitivity option for keyword matching and regex processing

### DIFF
--- a/app/config/config_model.py
+++ b/app/config/config_model.py
@@ -86,6 +86,7 @@ class Settings(BaseConfigModel):
     action_cooldown: Optional[int] = 300
     attachment_lines: int = 20
     hide_regex_in_title: Optional[bool] = False
+    case_sensitive: Optional[bool] = False
     excluded_keywords: Optional[List[Union[str, ExcludedKeywords]]] = None
     disable_notifications: Optional[bool] = None
     olivetin_url: Optional[str] = None
@@ -212,12 +213,14 @@ class RegexItem(KeywordItemBase):
     """
     regex: str
     template: Optional[str] = None # legacy
+    case_sensitive: Optional[bool] = False
 
 class KeywordItem(KeywordItemBase):
     """
     Model for a string-based keyword with optional settings.
     """
     keyword: str
+    case_sensitive: Optional[bool] = False
 
 
 class KeywordGroup(KeywordItemBase):
@@ -226,6 +229,7 @@ class KeywordGroup(KeywordItemBase):
     All keywords in the group must match for the group to trigger.
     """
     keyword_group: List[Union[str, KeywordItem, RegexItem]] = []
+    case_sensitive: Optional[bool] = False
 
 
 class KeywordBase(BaseModel):


### PR DESCRIPTION
Introduce a case sensitivity option for keyword matching and regex processing, allowing users to choose whether matches should be case-sensitive or not. This enhances the flexibility of keyword searches and regex evaluations.

```yaml
settings:
  case_sensitive: true

global_keywords:
  keywords:
    - regex: "^ERROR:"
      action: notify
    - regex: "^WARN:"
      action: send_alert
```

```yaml
keywords:
  - regex: "[A-Z]+.*FAILED"  # Matches only uppercase FAILED
    case_sensitive: true
    action: notify
  - regex: "[a-z]+.*failed"  # Matches only lowercase failed (unless case_sensitive is false)
    case_sensitive: false
    action: notify
```

Should resolve #69

Coded with the Copilot Agent