### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you find LoggiFly useful, drop a ⭐️ on the repo or buy me a coffee!
 
 # Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=clemcer/loggifly&type=Date)](https://www.star-history.com/#clemcer/loggifly&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=clemcer/loggifly&type=Date)](https://star-history.dera.page/#clemcer/loggifly&Date)
 
 ## License
 [MIT](https://github.com/clemcer/LoggiFly/blob/main/LICENSE)


### PR DESCRIPTION
The star history chart in the README stopped working because the old service relies on the GitHub stargazer API, which now restricts this kind of usage. Update the chart to use the replacement service so it renders again.